### PR TITLE
Remove journal service as it's not needed anymore by the constructor

### DIFF
--- a/Resources/config/buzz.xml
+++ b/Resources/config/buzz.xml
@@ -6,17 +6,14 @@
 
     <parameters>
         <parameter key="buzz.client.class">Buzz\Client\Curl</parameter>
-        <parameter key="buzz.journal.class">Buzz\History\Journal</parameter>
         <parameter key="buzz.browser.class">Buzz\Browser</parameter>
     </parameters>
 
     <services>
-        <service id="buzz.journal" class="%buzz.journal.class%" public="false" />
         <service id="buzz.client" class="%buzz.client.class%" public="false" />
 
         <service id="buzz" class="%buzz.browser.class%">
           <argument type="service" id="buzz.client" />
-          <argument type="service" id="buzz.journal" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
Fix "Catchable Fatal Error: Argument 2 passed to Buzz\Browser::__construct() must be an instance of Buzz\Message\FactoryInterface, instance of Buzz\History\Journal given"
