### PR TITLE
Fixed reference to non existent class.

### DIFF
--- a/Resources/config/buzz.xml
+++ b/Resources/config/buzz.xml
@@ -6,7 +6,7 @@
 
     <parameters>
         <parameter key="buzz.client.class">Buzz\Client\Curl</parameter>
-        <parameter key="buzz.message_factory.class">Buzz\Message\Factory\Factory</parameter>
+        <parameter key="buzz.message_factory.class">Buzz\Message\Factory</parameter>
         <parameter key="buzz.browser.class">Buzz\Browser</parameter>
     </parameters>
 


### PR DESCRIPTION
The buzz.xml configuration contained a reference to the Factory class using the wrong namespace.

This would result in a fatal error after installing this bundle.
