### PR TITLE
The min version of the kriswallsmith/buzz needs to be higher than 0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "kriswallsmith/buzz": ">= 0.6"
+        "kriswallsmith/buzz": "> 0.6"
     },
     "target-dir": "Sensio/Bundle/BuzzBundle",
     "autoload": {


### PR DESCRIPTION


The min version of the kriswallsmith/buzz needs to be at least higher than 0.6 since code has been refactored and moved. The Factory class now resides in the Factory folder