### PR TITLE
Added proxy config support

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -29,7 +29,9 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('client_timeout')
                     ->defaultValue(5)
-                    ->end()
+                ->end()
+                ->scalarNode('proxy')
+                    ->defaultNull()
                 ->end()
             ->end()
         ;

--- a/DependencyInjection/SensioBuzzExtension.php
+++ b/DependencyInjection/SensioBuzzExtension.php
@@ -23,5 +23,6 @@ class SensioBuzzExtension extends Extension
         $loader->load('buzz.xml');
 
         $container->setParameter('buzz.client.timeout', $config['client_timeout']);
+        $container->setParameter('buzz.client.proxy', $config['proxy']);
     }
 }

--- a/Resources/config/buzz.xml
+++ b/Resources/config/buzz.xml
@@ -16,6 +16,9 @@
             <call method="setTimeout">
                 <argument>%buzz.client.timeout%</argument>
             </call>
+            <call method="setProxy">
+                <argument>%buzz.client.proxy%</argument>
+            </call>
         </service>
 
         <service id="buzz" class="%buzz.browser.class%">


### PR DESCRIPTION
Added application level proxy configuration support.
So you can setup your proxy in the config.yml and use it with Buzz. 

```
sensio_buzz:
    proxy: proxy.example.com:8080
```
