### PR TITLE
Adding Symfony4 support

### DIFF
--- a/Resources/config/buzz.xml
+++ b/Resources/config/buzz.xml
@@ -25,6 +25,7 @@
           <argument type="service" id="buzz.client" />
           <argument type="service" id="buzz.message_factory" />
         </service>
+        <service id="Buzz\Browser" alias="buzz" />
     </services>
 </container>
 


### PR DESCRIPTION
Not much work was required, we extended service definition
so you can inject Buzz\Browser to your services

Change tested with 4.0 beta and 2.8 LTS - works. #SymfonyConHackday2017