### PR TITLE
Add more restrictions on the buzz version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "kriswallsmith/buzz": "> 0.6"
+        "kriswallsmith/buzz": ">0.6, <0.17"
     },
     "target-dir": "Sensio/Bundle/BuzzBundle",
     "autoload": {


### PR DESCRIPTION
I will soon release Buzz 0.17 and I see that this bundle is not compatible with the new version. 

For Symfony `^3.3 || ^4.0` support, see https://github.com/symfony/recipes-contrib/pull/328